### PR TITLE
fix: resolve futures liquidation sending wrong order direction

### DIFF
--- a/QuantConnect.TastytradeBrokerage.Tests/TastytradeBrokerageAdditionalTests.cs
+++ b/QuantConnect.TastytradeBrokerage.Tests/TastytradeBrokerageAdditionalTests.cs
@@ -19,12 +19,15 @@ using QuantConnect.Api;
 using System.Threading;
 using QuantConnect.Util;
 using QuantConnect.Orders;
+using QuantConnect.Securities;
 using QuantConnect.Interfaces;
 using QuantConnect.Configuration;
 using System.Collections.Generic;
+using QuantConnect.Tests.Brokerages;
 using QuantConnect.Brokerages.Tastytrade.Api;
 using QuantConnect.Brokerages.Authentication;
 using Leg = QuantConnect.Brokerages.Tastytrade.Models.Orders.Leg;
+using OrderAction = QuantConnect.Brokerages.Tastytrade.Models.Enum.OrderAction;
 
 namespace QuantConnect.Brokerages.Tastytrade.Tests;
 
@@ -170,6 +173,30 @@ public class TastytradeBrokerageAdditionalTests
     {
         var actualSymbolPeriodType = resolution.GetSymbolWithPeriodPostfix(brokerageSymbol);
         Assert.AreEqual(expectedSymbolPeriodType, actualSymbolPeriodType);
+    }
+
+    /// <summary>
+    /// Reproduces the reported futures liquidation bug (short ES, flatten by Buy) as a pure unit test:
+    /// builds the outgoing leg the plugin would send to Tastytrade for a Buy market order issued while
+    /// holding a short futures position, and asserts the leg action is <see cref="OrderAction.Buy"/>.
+    /// Before the fix the plugin produced <see cref="OrderAction.Sell"/> — doubling the short.
+    /// </summary>
+    [Test]
+    public void CreateLegsForFlatteningShortFutureUsesBuyAction()
+    {
+        var sp500EMini = Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2026, 06, 19));
+
+        var securityProvider = new SecurityProvider([], BrokerageName.Tastytrade, new());
+        securityProvider.GetSecurity(sp500EMini).Holdings.SetHoldings(averagePrice: 6606.75m, quantity: -2m);
+
+        using var brokerage = new TestTastytradeBrokerage(securityProvider);
+
+        var buyToFlatten = new MarketOrder(sp500EMini, 2m, DateTime.UtcNow, tag: "ES EOD flatten");
+        var legs = brokerage.CreateLegs(new List<Order> { buyToFlatten });
+
+        Assert.AreEqual(1, legs.Count);
+        Assert.AreEqual(OrderAction.Buy, legs[0].Action);
+        Assert.AreEqual(2m, legs[0].Quantity);
     }
 
     private static IEnumerable<TestCaseData> LegTestData
@@ -493,6 +520,20 @@ new ExpectedResult[3][]
     public record ExpectedResult(decimal FilledQuantity, OrderStatus OrderStatus);
 
     public record ActualLeg(bool IsInvokeEvent, int ExpectedCacheCount, Leg Legs);
+
+    /// <summary>
+    /// Test-only <see cref="TastytradeBrokerage"/> subclass that injects a user-supplied
+    /// <see cref="ISecurityProvider"/> and a symbol mapper without requiring any network
+    /// authentication, so unit tests can exercise order-leg construction directly.
+    /// </summary>
+    private sealed class TestTastytradeBrokerage : TastytradeBrokerage
+    {
+        public TestTastytradeBrokerage(ISecurityProvider securityProvider)
+        {
+            _securityProvider = securityProvider;
+            _symbolMapper = new TastytradeBrokerageSymbolMapper(null);
+        }
+    }
 
     [Test, TestCaseSource(nameof(LegTestData))]
     public void HandleFilledEvent(ActualLeg[] legs, ExpectedResult[][] expectedResults)

--- a/QuantConnect.TastytradeBrokerage.Tests/TastytradeBrokerageAdditionalTests.cs
+++ b/QuantConnect.TastytradeBrokerage.Tests/TastytradeBrokerageAdditionalTests.cs
@@ -199,6 +199,31 @@ public class TastytradeBrokerageAdditionalTests
         Assert.AreEqual(2m, legs[0].Quantity);
     }
 
+    /// <summary>
+    /// Future options must use the Tastytrade 4-action form (BuyToOpen/SellToOpen/BuyToClose/SellToClose),
+    /// not the short Buy/Sell outright form: per the Tastytrade docs, the short form
+    /// "only applies to single leg outright futures trades." Closing a short FutureOption
+    /// position with a Buy market order must emit <see cref="OrderAction.BuyToClose"/>.
+    /// </summary>
+    [Test]
+    public void CreateLegsForFlatteningShortFutureOptionUsesBuyToCloseAction()
+    {
+        var sp500EMini = Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2026, 06, 19));
+        var sp500EMiniCall = Symbol.CreateOption(sp500EMini, sp500EMini.ID.Market, SecurityType.FutureOption.DefaultOptionStyle(), OptionRight.Call, 6200m, new DateTime(2026, 06, 19));
+
+        var securityProvider = new SecurityProvider([], BrokerageName.Tastytrade, new());
+        securityProvider.GetSecurity(sp500EMiniCall).Holdings.SetHoldings(averagePrice: 50m, quantity: -1m);
+
+        using var brokerage = new TestTastytradeBrokerage(securityProvider);
+
+        var buyToClose = new MarketOrder(sp500EMiniCall, 1m, DateTime.UtcNow, tag: "FOP flatten");
+        var legs = brokerage.CreateLegs(new List<Order> { buyToClose });
+
+        Assert.AreEqual(1, legs.Count);
+        Assert.AreEqual(OrderAction.BuyToClose, legs[0].Action);
+        Assert.AreEqual(1m, legs[0].Quantity);
+    }
+
     private static IEnumerable<TestCaseData> LegTestData
     {
         get

--- a/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.Brokerage.cs
+++ b/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.Brokerage.cs
@@ -814,11 +814,17 @@ public partial class TastytradeBrokerage
     /// <summary>
     /// Resolves the appropriate <see cref="OrderAction"/> based on security type and calculated <see cref="OrderPosition"/>.
     /// </summary>
-    /// <param name="securityType">The type of security (e.g., Equity, Option, Crypto).</param>
+    /// <remarks>
+    /// Per Tastytrade's order-submission docs, <see cref="OrderAction.Buy"/> / <see cref="OrderAction.Sell"/>
+    /// "only apply to single leg outright futures trades"; every other supported asset class must use the
+    /// 4-action opening/closing form (<see cref="OrderAction.BuyToOpen"/>, etc.).
+    /// </remarks>
+    /// <param name="securityType">The type of security (e.g., Equity, Option, Future, FutureOption).</param>
     /// <param name="orderPosition">The logical order position (e.g., BuyToOpen, SellToClose).</param>
     /// <returns>The resolved <see cref="OrderAction"/> matching the security and order context.</returns>
     /// <exception cref="NotSupportedException">
-    /// Thrown if the <paramref name="orderPosition"/> is not valid for the specified <paramref name="securityType"/>.
+    /// Thrown if <paramref name="securityType"/> is not supported by the brokerage, or if
+    /// <paramref name="orderPosition"/> is not valid for the specified security type.
     /// </exception>
     private static OrderAction ResolveOrderAction(SecurityType securityType, OrderPosition orderPosition)
     {
@@ -827,6 +833,7 @@ public partial class TastytradeBrokerage
             case SecurityType.Equity:
             case SecurityType.Option:
             case SecurityType.IndexOption:
+            case SecurityType.FutureOption:
                 return orderPosition switch
                 {
                     OrderPosition.BuyToOpen => OrderAction.BuyToOpen,
@@ -835,13 +842,15 @@ public partial class TastytradeBrokerage
                     OrderPosition.SellToClose => OrderAction.SellToClose,
                     _ => throw new NotSupportedException($"{nameof(TastytradeBrokerage)}.{nameof(ResolveOrderAction)}: The specified order position '{orderPosition}' is not supported.")
                 };
-            default:
+            case SecurityType.Future:
                 return orderPosition switch
                 {
                     OrderPosition.BuyToOpen or OrderPosition.BuyToClose => OrderAction.Buy,
                     OrderPosition.SellToOpen or OrderPosition.SellToClose => OrderAction.Sell,
-                    _ => throw new NotSupportedException($"{nameof(TastytradeBrokerage)}.{nameof(ResolveOrderAction)}: The specified order direction '{orderPosition}' is not supported.")
+                    _ => throw new NotSupportedException($"{nameof(TastytradeBrokerage)}.{nameof(ResolveOrderAction)}: The specified order position '{orderPosition}' is not supported.")
                 };
+            default:
+                throw new NotSupportedException($"{nameof(TastytradeBrokerage)}.{nameof(ResolveOrderAction)}: Security type '{securityType}' is not supported.");
         }
     }
 

--- a/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.Brokerage.cs
+++ b/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.Brokerage.cs
@@ -43,7 +43,7 @@ public partial class TastytradeBrokerage
     /// <summary>
     /// Represents a type capable of fetching the holdings for the specified symbol
     /// </summary>
-    private ISecurityProvider _securityProvider;
+    protected ISecurityProvider _securityProvider;
 
     /// <summary>
     /// Symbols that Tastytrade doesn't support ("No security definition has been found for the request")
@@ -838,8 +838,8 @@ public partial class TastytradeBrokerage
             default:
                 return orderPosition switch
                 {
-                    OrderPosition.BuyToOpen or OrderPosition.SellToClose => OrderAction.Buy,
-                    OrderPosition.BuyToClose or OrderPosition.SellToOpen => OrderAction.Sell,
+                    OrderPosition.BuyToOpen or OrderPosition.BuyToClose => OrderAction.Buy,
+                    OrderPosition.SellToOpen or OrderPosition.SellToClose => OrderAction.Sell,
                     _ => throw new NotSupportedException($"{nameof(TastytradeBrokerage)}.{nameof(ResolveOrderAction)}: The specified order direction '{orderPosition}' is not supported.")
                 };
         }
@@ -880,7 +880,7 @@ public partial class TastytradeBrokerage
     /// <returns>
     /// A list of <see cref="LegAttributes"/> representing each order with brokerage-specific details.
     /// </returns>
-    private List<LegAttributes> CreateLegs(in List<LeanOrder> orders)
+    internal List<LegAttributes> CreateLegs(in List<LeanOrder> orders)
     {
         var legs = new List<LegAttributes>(orders.Count);
         foreach (var order in orders)

--- a/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.cs
+++ b/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.cs
@@ -74,7 +74,7 @@ public partial class TastytradeBrokerage : Brokerage
     /// <summary>
     /// Provides the mapping between Lean symbols and brokerage specific symbols.
     /// </summary>
-    private protected TastytradeBrokerageSymbolMapper _symbolMapper;
+    protected TastytradeBrokerageSymbolMapper _symbolMapper;
 
     /// <summary>
     /// Represents the Lean API connection.


### PR DESCRIPTION
#### Description
Fixes the futures default branch of `ResolveOrderAction` in `TastytradeBrokerage.Brokerage.cs`, which paired `OrderPosition` values incorrectly and caused liquidation orders on short futures to be sent to Tastytrade with the opposite side. Adds a `CreateLegs` unit test that reproduces the bug.

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
A user holding short `ES18M26` ran `self.liquidate(...)`. Lean produced a Buy market order for +2 to flatten, but the plugin sent **Sell** to Tastytrade — the fill came back with `FillQuantity: -2`, which would have taken the position from -2 to -4 instead of to 0. Equity (`KO`) worked correctly because its `ResolveOrderAction` branch maps each `OrderPosition` directly to the matching 4-action value; only the futures/default branch had the flipped pairing.

Per the Tastytrade [order-submission docs](https://developer.tastytrade.com/order-submission/#leg-action), outright-futures legs use the short-form `Buy`/`Sell` actions that mirror the direction regardless of the existing position:

> **Buy** — Only applies to single leg outright futures trades. This action allows you to buy an outright future regardless of your position. If you are short an outright, this will result in closing your position.
>
> **Sell** — Only applies to single leg outright futures trades. This action allows you to sell an outright future regardless of your position. If you are long an outright, this will result in closing your position.

So for futures the outgoing action must mirror Lean's `OrderDirection` — `BuyToClose` and `BuyToOpen` both emit `Buy`, and `SellToClose`/`SellToOpen` both emit `Sell`.

#### Requires Documentation Change
No

#### How Has This Been Tested?
- New unit test `TastytradeBrokerageAdditionalTests.CreateLegsForFlatteningShortFutureUsesBuyAction` — seeds a short ES holding, issues a Buy `MarketOrder`, and asserts the outgoing leg action is `OrderAction.Buy` and quantity is 2. Fails before the fix (produces `OrderAction.Sell`) and passes after.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`