### PR TITLE
feature: enable concurrent message processing

### DIFF
--- a/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.cs
+++ b/QuantConnect.TastytradeBrokerage/TastytradeBrokerage.cs
@@ -94,6 +94,12 @@ public partial class TastytradeBrokerage : Brokerage
         && _clientWrapperByWebSocketType[WebSocketType.MarketData]?.IsOpen == true;
 
     /// <summary>
+    /// Indicates whether the brokerage supports concurrent processing of incoming messages,
+    /// allowing reads to occur in parallel with writes guarded by <see cref="BrokerageConcurrentMessageHandler{T}.WithLockedStream"/>.
+    /// </summary>
+    public override bool ConcurrencyEnabled => true;
+
+    /// <summary>
     /// Parameterless constructor for brokerage.
     /// </summary>
     /// <remarks>
@@ -234,7 +240,7 @@ public partial class TastytradeBrokerage : Brokerage
         }
         _clientWrapperByWebSocketType[WebSocketType.MarketData] = new MarketDataWebSocketClientWrapper(_tastytradeApiClient, OnReSubscriptionProcess, OnMarketDataMessageHandler, OnMessage);
 
-        _messageHandler = new BrokerageConcurrentMessageHandler<Order>(OnOrderUpdateReceivedHandler);
+        _messageHandler = new BrokerageConcurrentMessageHandler<Order>(OnOrderUpdateReceivedHandler, ConcurrencyEnabled);
     }
 
     /// <summary>


### PR DESCRIPTION
#### Description
Override `ConcurrencyEnabled => true` on `TastytradeBrokerage` and pass it through to the `BrokerageConcurrentMessageHandler<Order>` constructor. This switches the handler's internal lock from `MonitorWrapper` to `ReaderWriterLockWrapper`, allowing incoming account/order stream messages to be read concurrently while `WithLockedStream()` still serializes order submission (`PlaceOrder`/`UpdateOrder`/`CancelOrder`).

#### Related Issue
N/A

#### Motivation and Context
Aligns Tastytrade with the concurrent processing model already in place for other brokerages (TradeStation, Charles Schwab, Alpaca, Binance, Bybit, OANDA, IB, Eze). Reduces contention between account stream reads and order-placement writes, improving throughput when many order updates arrive during active trading.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
> Environment: Live

| Wave | Order Type | Order Count | Expected Order Status | TotalTime (ms) | Concurrency | Connection |
| ------ | ------------ | -------------- | ------------------------ | ---------------- | -------------- | ------------- |
| 1 | Market | 90 | 27220 ms | Submitted | :white_circle: | Lan |
| 1 | Market | 90 | 27277 ms | Filled | :white_circle: | Lan |
| 2 | Market | 90 | 13444 ms | Submitted | :white_check_mark: | Lan |
| 2 | Market | 90 | 13602 ms | Filled | :white_check_mark: | Lan |

> Environment: Paper
- I can not give the expected test measuring.
- Received a `timeout` often when placing an order.
- The `paper` allows for no more than 50 orders.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`